### PR TITLE
fix for price-impact / add confirm when price impact >5 / show notice…

### DIFF
--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -8,7 +8,7 @@ import { RowBetween, RowFixed } from '../Row'
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 
-enum SlippageError {
+export enum SlippageError {
     InvalidInput = 'InvalidInput',
     RiskyLow = 'RiskyLow',
     RiskyHigh = 'RiskyHigh'
@@ -69,7 +69,7 @@ const OptionCustom = styled(FancyButton) <{ active?: boolean; warning?: boolean 
     }
 `
 
-const SlippageEmojiContainer = styled.span`
+export const SlippageEmojiContainer = styled.span`
     color: #f3841e;
     ${({ theme }) => theme.mediaWidth.upToSmall`
     display: none;  

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -394,7 +394,7 @@ export const ALLOWED_PRICE_IMPACT_LOW: Percent = new Percent(JSBI.BigInt(100), B
 export const ALLOWED_PRICE_IMPACT_MEDIUM: Percent = new Percent(JSBI.BigInt(300), BIPS_BASE) // 3%
 export const ALLOWED_PRICE_IMPACT_HIGH: Percent = new Percent(JSBI.BigInt(500), BIPS_BASE) // 5%
 // if the price slippage exceeds this number, force the user to type 'confirm' to execute
-export const PRICE_IMPACT_WITHOUT_FEE_CONFIRM_MIN: Percent = new Percent(JSBI.BigInt(1000), BIPS_BASE) // 10%
+export const PRICE_IMPACT_WITHOUT_FEE_CONFIRM_MIN: Percent = new Percent(JSBI.BigInt(500), BIPS_BASE) // 10%
 // for non expert mode disable swaps above this
 export const BLOCKED_PRICE_IMPACT_NON_EXPERT: Percent = new Percent(JSBI.BigInt(1500), BIPS_BASE) // 15%
 

--- a/src/pages/gd/Swap/SwapConfirmModal/index.tsx
+++ b/src/pages/gd/Swap/SwapConfirmModal/index.tsx
@@ -17,6 +17,7 @@ import { Action } from 'pages/gd/Stake/StakeDeposit'
 import { getExplorerLink } from 'utils'
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
+import confirmPriceImpactWithoutFee from 'components/swap/confirmPriceImpactWithoutFee'
 
 export interface SwapConfirmModalProps extends SwapDetailsFields {
     className?: string
@@ -67,6 +68,11 @@ function SwapConfirmModal({
     const [hash, setHash] = useState('')
 
     const handleSwap = async () => {
+      
+        if (meta && meta.priceImpact && !confirmPriceImpactWithoutFee(meta.priceImpactPCT)) {
+          return
+        }
+
         setStatus('CONFIRM')
 
         const onSent = (hash: string, from: string) => {

--- a/src/pages/gd/Swap/SwapConfirmModal/index.tsx
+++ b/src/pages/gd/Swap/SwapConfirmModal/index.tsx
@@ -18,6 +18,7 @@ import { getExplorerLink } from 'utils'
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 import confirmPriceImpactWithoutFee from 'components/swap/confirmPriceImpactWithoutFee'
+import { Percent } from '@sushiswap/sdk'
 
 export interface SwapConfirmModalProps extends SwapDetailsFields {
     className?: string
@@ -69,7 +70,7 @@ function SwapConfirmModal({
 
     const handleSwap = async () => {
       
-        if (meta && meta.priceImpact && !confirmPriceImpactWithoutFee(meta.priceImpactPCT)) {
+        if (meta && meta.priceImpact && !confirmPriceImpactWithoutFee((meta.priceImpact as unknown as Percent))) {
           return
         }
 

--- a/src/pages/gd/Swap/SwapSettings/index.tsx
+++ b/src/pages/gd/Swap/SwapSettings/index.tsx
@@ -9,6 +9,7 @@ import createNumberMask from 'text-mask-addons/dist/createNumberMask'
 import { useSwap } from '../hooks'
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
+import { SlippageError, SlippageEmojiContainer} from 'components/TransactionSettings/'
 
 const settingsIcon = (
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -43,6 +44,14 @@ function SwapSettings({ className, style }: SwapSettingsProps) {
     const open = useModalOpen(ApplicationModal.SETTINGS)
     const handleClick = useToggleSettingsMenu()
     const { slippageTolerance, setSlippageTolerance } = useSwap()
+    let slippageError: SlippageError | undefined
+    if (parseFloat(slippageTolerance.value) < 0.05) {
+      slippageError = SlippageError.RiskyLow
+    } else if (parseFloat(slippageTolerance.value) > 1) {
+      slippageError = SlippageError.RiskyHigh
+    } else {
+      slippageError = undefined
+    }
 
     return (
         <>
@@ -105,7 +114,8 @@ function SwapSettings({ className, style }: SwapSettingsProps) {
                                 size={3}
                                 guide={false}
                                 mask={percentageMask}
-                                value={slippageTolerance.custom ? slippageTolerance.value : ''}
+                                value={slippageTolerance.custom ? slippageTolerance.value : ''
+                                }
                                 onChange={event =>
                                     setSlippageTolerance({
                                         custom: true,
@@ -115,6 +125,17 @@ function SwapSettings({ className, style }: SwapSettingsProps) {
                             />
                         </div>
                     </div>
+                    {!!slippageError && (
+                      <div style={{ fontSize: '14px', paddingTop: '7px',color: '#F3841E'}}>
+                              <SlippageEmojiContainer>
+                                <span role="img" aria-label="warning" style={{
+                                }}>⚠️</span>
+                              </SlippageEmojiContainer>
+                          {slippageError === SlippageError.RiskyLow
+                                  ? i18n._(t`Your transaction may fail`)
+                                  : i18n._(t`Your transaction may be frontrun`)}
+                      </div>
+                    )}
                     <Title className="flex items-center" type="field" style={{ marginTop: 29 }}>
                         {i18n._(t`Transaction deadline`)}{' '}
                         <QuestionHelper

--- a/src/sdk/buy.ts
+++ b/src/sdk/buy.ts
@@ -10,6 +10,7 @@ import {
     TradeType,
     computePriceImpact
 } from '@uniswap/sdk-core'
+import { Percent as pctSushi } from '@sushiswap/sdk' 
 import { Trade } from '@uniswap/v2-sdk'
 import { MaxUint256 } from '@ethersproject/constants'
 import { getToken } from './methods/tokenLists'
@@ -46,6 +47,7 @@ export type BuyInfo = {
     GDXAmount: CurrencyAmount<Currency> | Fraction
 
     priceImpact: Fraction
+    priceImpactPCT:  pctSushi
     slippageTolerance: Percent
 
     liquidityFee: CurrencyAmount<Currency>
@@ -413,8 +415,10 @@ export async function getMeta(
         }
 
         const { cDAI: price } = await g$ReservePrice(web3, chainId)
-        priceImpact = computePriceImpact(price, inputCDAIValue, outputAmount)
+        priceImpact = computePriceImpact(price, inputCDAIValue, minimumOutputAmount)
     }
+
+    const priceImpactPCT = priceImpact as unknown as pctSushi
 
     debugGroupEnd(`Get meta ${amount} ${fromSymbol} to G$`)
     debug('Route', route)
@@ -429,6 +433,7 @@ export async function getMeta(
         GDXAmount: outputAmount,
 
         priceImpact,
+        priceImpactPCT,
         slippageTolerance: slippageTolerancePercent,
 
         liquidityFee,

--- a/src/sdk/buy.ts
+++ b/src/sdk/buy.ts
@@ -10,7 +10,6 @@ import {
     TradeType,
     computePriceImpact
 } from '@uniswap/sdk-core'
-import { Percent as pctSushi } from '@sushiswap/sdk' 
 import { Trade } from '@uniswap/v2-sdk'
 import { MaxUint256 } from '@ethersproject/constants'
 import { getToken } from './methods/tokenLists'
@@ -47,7 +46,6 @@ export type BuyInfo = {
     GDXAmount: CurrencyAmount<Currency> | Fraction
 
     priceImpact: Fraction
-    priceImpactPCT:  pctSushi
     slippageTolerance: Percent
 
     liquidityFee: CurrencyAmount<Currency>
@@ -418,8 +416,6 @@ export async function getMeta(
         priceImpact = computePriceImpact(price, inputCDAIValue, minimumOutputAmount)
     }
 
-    const priceImpactPCT = priceImpact as unknown as pctSushi
-
     debugGroupEnd(`Get meta ${amount} ${fromSymbol} to G$`)
     debug('Route', route)
 
@@ -433,7 +429,6 @@ export async function getMeta(
         GDXAmount: outputAmount,
 
         priceImpact,
-        priceImpactPCT,
         slippageTolerance: slippageTolerancePercent,
 
         liquidityFee,

--- a/src/sdk/sell.ts
+++ b/src/sdk/sell.ts
@@ -10,7 +10,6 @@ import {
     Token,
     TradeType
 } from '@uniswap/sdk-core'
-import { Percent as pctSushi } from '@sushiswap/sdk'
 import { Trade } from '@uniswap/v2-sdk'
 import { MaxUint256 } from '@ethersproject/constants'
 import { getToken } from './methods/tokenLists'
@@ -380,8 +379,6 @@ export async function getMeta(
 
         GDXBalance = await tokenBalance(web3, 'GDX', account)
     }
-
-    const priceImpactPCT = priceImpact as unknown as pctSushi
     
     debugGroupEnd(`Get meta ${amount} G$ to ${toSymbol}`)
 
@@ -395,7 +392,6 @@ export async function getMeta(
         GDXAmount: inputAmount.lessThan(GDXBalance) ? inputAmount : GDXBalance,
 
         priceImpact,
-        priceImpactPCT,
         slippageTolerance: slippageTolerancePercent,
         contribution,
 

--- a/src/sdk/sell.ts
+++ b/src/sdk/sell.ts
@@ -10,6 +10,7 @@ import {
     Token,
     TradeType
 } from '@uniswap/sdk-core'
+import { Percent as pctSushi } from '@sushiswap/sdk'
 import { Trade } from '@uniswap/v2-sdk'
 import { MaxUint256 } from '@ethersproject/constants'
 import { getToken } from './methods/tokenLists'
@@ -380,6 +381,8 @@ export async function getMeta(
         GDXBalance = await tokenBalance(web3, 'GDX', account)
     }
 
+    const priceImpactPCT = priceImpact as unknown as pctSushi
+    
     debugGroupEnd(`Get meta ${amount} G$ to ${toSymbol}`)
 
     return {
@@ -392,6 +395,7 @@ export async function getMeta(
         GDXAmount: inputAmount.lessThan(GDXBalance) ? inputAmount : GDXBalance,
 
         priceImpact,
+        priceImpactPCT,
         slippageTolerance: slippageTolerancePercent,
         contribution,
 


### PR DESCRIPTION
… for potential fail/front run tx

# Description

Price Impact now uses minimumAmount
Confirm box is shown when price impact >5% 
Notice shown on transaction settings for potentially failed/front-run tx (threshold <0.05 / >1)

About # (link your issue here)
https://github.com/GoodDollar/GoodProtocolUI/issues/148

# How Has This Been Tested?

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [x] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes

# Visuals
![image](https://user-images.githubusercontent.com/6606028/154508151-3dc2a257-d13a-4c62-bfe2-9366797f5cd9.png)

![image](https://user-images.githubusercontent.com/6606028/154510566-a484b5f5-4641-462d-9e4e-981dbf185fc7.png)

The confirmation box is taken from the function in place from Sushi
we might want to think about changing it to be a styled component?
