### PR TITLE
Bug: removed backdrop-filter classes cause of empty tailwind var…

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -78,7 +78,7 @@ function AppBar(): JSX.Element {
 
     return (
         <AppBarWrapper className="flex flex-row flex-nowrap justify-between w-screen relative z-10">
-            <Disclosure as="nav" className="w-screen gradiant-z-10 backdrop-filter backdrop-blur">
+            <Disclosure as="nav" className="w-screen gradiant-z-10">
                 {({ open }) => (
                     <>
                         <div className="px-4 py-1.5">


### PR DESCRIPTION
…iables / broke nav-bar rendering

# Description

classes backdrop-filter / backdrop-blur used but tailwind renders empty variables, which apparently break the nav-bars
also, I believe they are misplaced considering the desired effect
quickfix to remove them for now, to make nav-bars work across all mobile browsers

Changes for the desired effect will be depending on design decisions

About # (link your issue here)
https://github.com/GoodDollar/GoodProtocolUI/issues/155

# How Has This Been Tested?

Locally

# Related Screenshots

See [issue](https://github.com/GoodDollar/GoodProtocolUI/issues/155)

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [x] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
