### PR TITLE
Feature: add loading indicators for walletbalance & swap output amount

### DIFF
--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -15,6 +15,7 @@ import { AdditionalChainId } from '../constants'
 import useMetaMask from '../hooks/useMetaMask'
 import LanguageSwitch from "./LanguageSwitch"
 import { useApplicationTheme } from '../state/application/hooks'
+import WalletBalance, { Balances } from 'components/WalletBalance'
 
 const SideBarSC = styled.aside<{ $mobile?: boolean }>`
   width: ${({ $mobile }) => ($mobile ? '90%' : '268px')};
@@ -215,9 +216,12 @@ export default function SideBar({ mobile, closeSidebar }: { mobile?: boolean, cl
             gdao: gdao && new Token(chainId, (gdao as any).address, gdao.decimals, gdao.symbol, gdao.name)
         }
     }, [chainId])
-    const g$Balance = useTokenBalance(account, data?.g$)
-    const gdxBalance = useTokenBalance(account, data?.gdx)
-    const gdaoBalance = useTokenBalance(account, data?.gdao)
+
+    const balances:Balances = {
+      G$: useTokenBalance(account, data?.g$),
+      GDX: useTokenBalance(account, data?.gdx),
+      GDAO: useTokenBalance(account, data?.gdao), 
+    }
 
     const importToMetamask = async () => {
         const allTokens = []
@@ -287,6 +291,7 @@ export default function SideBar({ mobile, closeSidebar }: { mobile?: boolean, cl
     return (
         <SideBarSC className="flex flex-col justify-between" $mobile={mobile}>
             <div className="sidebar-inner-container">
+              { account && (
                 <div className="balance">
                     <div className="flex items-center justify-between title">
                         <span>{i18n._(t`Wallet balance`)}</span>
@@ -313,27 +318,17 @@ export default function SideBar({ mobile, closeSidebar }: { mobile?: boolean, cl
                             </defs>
                         </svg>
                     </div>
-                    <div className="details">
-                        <div>
-                            G$ {g$Balance?.toExact({ groupSeparator: ',' }) ?? '-'}
-                            {(chainId as any) !== AdditionalChainId.FUSE && (
-                                <>
-                                    <br />
-                                    GDX {gdxBalance?.toExact({ groupSeparator: ',' }) ?? '-'}
-                                </>
-                            )}
-                            <br />
-                            GOOD {gdaoBalance?.toSignificant(6, { groupSeparator: ',' }) ?? '-'}
-                        </div>
+                      <div className="details flex flex-col">                  
+                        <WalletBalance balances={balances} chainId={chainId} />
                         <br />
-
                         {localStorage.getItem(`${chainId}_metamask_import_status`) !== 'true' && (
                             <div className="importToMetamaskLink" onClick={importToMetamask}>
                                 Import to Metamask
                             </div>
                         )}
-                    </div>
+                      </div>
                 </div>
+              )}
                 <nav className="mt-5">
                   <NavLink to={'/dashboard'} onClick={mobile ? closeSidebar : null }>{i18n._(t`Dashboard`)}</NavLink>
                   <NavLink to={'/swap'} onClick={mobile ? closeSidebar : null }>{i18n._(t`Swap`)}</NavLink>

--- a/src/components/WalletBalance/index.tsx
+++ b/src/components/WalletBalance/index.tsx
@@ -1,0 +1,50 @@
+import React, {Fragment, useEffect, useState} from 'react'
+import { ChainId, TokenAmount } from '@sushiswap/sdk'
+import { AdditionalChainId } from '../../constants'
+import { CustomLightSpinner } from 'theme'
+import Circle from 'assets/images/blue-loader.svg'
+
+export interface Balances {
+  G$: TokenAmount | undefined,
+  GDX: TokenAmount | undefined,
+  GDAO: TokenAmount | undefined
+}
+
+export type WalletBalanceProps = {
+  balances: Balances,
+  chainId: ChainId,
+}
+
+export default function WalletBalance(props: WalletBalanceProps): JSX.Element {
+  const { balances, chainId } = props
+  const [balance, setBalance] = useState<JSX.Element[]>()
+
+  useEffect(() => {
+    const newBalance = Object.entries(balances).map((balance) => {
+      const token = balance[0]
+      const amount = balance[1]
+      if ((chainId as any) === AdditionalChainId.FUSE && token === 'GDX') return <div key={token}></div>
+      const frag = (
+        <Fragment key={token}>
+          <span className="flex">
+            {token} - {
+              !amount ?
+                <CustomLightSpinner key={token} src={Circle} alt="loader" size={'16px'} className="ml-1.5" /> :
+                token === 'GDAO' ?
+                  amount.toSignificant(6, {groupSeperator: ','}) :
+                  amount.toExact({ groupSeperator: ','})
+            }
+          </span>
+        </Fragment>
+      )
+      return frag
+    })
+    setBalance(newBalance)
+  }, [chainId, balances])
+
+  return (
+      <div className="flex flex-col">
+      { balance }
+      </div>
+    )
+}

--- a/src/pages/gd/Swap/SwapInput/index.tsx
+++ b/src/pages/gd/Swap/SwapInput/index.tsx
@@ -4,6 +4,8 @@ import MaskedInput from 'react-text-mask'
 import createNumberMask from 'text-mask-addons/dist/createNumberMask'
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
+import { CustomLightSpinner } from 'theme'
+import Circle from 'assets/images/blue-loader.svg'
 
 export interface SwapInputProps extends Omit<JSX.IntrinsicElements['input'], 'ref'> {
     className?: string
@@ -11,7 +13,8 @@ export interface SwapInputProps extends Omit<JSX.IntrinsicElements['input'], 're
     balance?: string | number
     autoMax?: boolean
     decimals?: number
-    onMax?: MouseEventHandler<HTMLButtonElement>
+    onMax?: MouseEventHandler<HTMLButtonElement>,
+    calculating?: boolean
 }
 
 function SwapInput({ className, style, autoMax, balance, decimals = 18, onMax, ...inputProps }: SwapInputProps) {
@@ -36,13 +39,16 @@ function SwapInput({ className, style, autoMax, balance, decimals = 18, onMax, .
                         {i18n._(t`max`)}
                     </SwapInputMaxButton>
                 )}
-                <MaskedInput
+                { inputProps.calculating ? 
+                  <CustomLightSpinner src={Circle} alt="loader" size={'24px'} /> :
+                  <MaskedInput
                     placeholder={'0.' + '0'.repeat(Math.min(decimals, 2))}
                     mask={mask}
                     guide={false}
                     size={1}
                     {...inputProps}
-                />
+                  />
+                }
             </SwapInputSC>
             {balance != undefined && (
                 <SwapInputBalance className="mt-2">

--- a/src/pages/gd/Swap/SwapRow/index.tsx
+++ b/src/pages/gd/Swap/SwapRow/index.tsx
@@ -28,7 +28,8 @@ export interface SwapRowProps {
     token?: Currency
     tokenList?: Currency[]
     onTokenChange?: (token: Currency) => any
-    alternativeSymbol?: string
+    alternativeSymbol?: string,
+    isCalculating?: boolean
 }
 
 function SwapRow({
@@ -43,7 +44,8 @@ function SwapRow({
     token,
     onTokenChange,
     tokenList,
-    alternativeSymbol
+    alternativeSymbol,
+    isCalculating
 }: SwapRowProps) {
     const [showSelect, setShowSelect] = useState(false)
 
@@ -89,6 +91,9 @@ function SwapRow({
                     decimals={token?.decimals}
                     onMax={handleSetMax}
                     onChange={handleInputChange}
+                    {
+                      ...(isCalculating && {calculating: isCalculating})
+                    }
                 />
             </div>
             {select && (

--- a/src/pages/gd/Swap/index.tsx
+++ b/src/pages/gd/Swap/index.tsx
@@ -72,6 +72,8 @@ function Swap() {
     const web3 = useWeb3()
     const [lastEdited, setLastEdited] = useState<{ field: 'external' | 'internal' }>()
 
+    const [calculating, setCalculating] = useState(false)
+
     const metaTimer = useRef<any>()
     useEffect(() => {
         clearTimeout(metaTimer.current)
@@ -96,6 +98,7 @@ function Swap() {
         }
 
         const timer = (metaTimer.current = setTimeout(async () => {
+          setCalculating(true)
             const meta = await getMeta(web3, symbol, value, parseFloat(slippageTolerance.value)).catch(e => {
                 console.error(e)
                 return null
@@ -112,6 +115,7 @@ function Swap() {
                     : meta.outputAmount.toExact()
             )
             setMeta(meta)
+            setCalculating(false)
         }, 400))
     }, [account, chainId, lastEdited, buying, web3, slippageTolerance.value])
     const [approving, setApproving] = useState(false)
@@ -318,6 +322,7 @@ function Swap() {
                                 setSwapValue(value)
                                 setLastEdited({ field: 'internal' })
                             }}
+                            isCalculating={calculating}
                             style={{ marginTop: buying ? 13 : 0, marginBottom: buying ? 0 : 13, order: buying ? 3 : 1 }}
                         />
                         <div style={{ marginTop: 14, padding: '0 4px' }}>


### PR DESCRIPTION
# Description

Added some loading circles and removed wallet balance from showing before a wallet is connected

About # (link your issue here)
#188 

# Checklist:
- [x] PR title matches follow: (Feature|Bug|Chore) Task Name
- [x] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [x] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes

# Additional Context
Calculating output amount:
![calculating_swap](https://user-images.githubusercontent.com/6606028/172102974-3584a91f-a582-4dfc-880a-e170efe153b7.png)

Loading balances:
![loading_balances](https://user-images.githubusercontent.com/6606028/172103003-11f13e17-47df-4588-9145-51dae9b8c02a.png)

