### PR TITLE
fix: posthog first time loading delay

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -76,23 +76,23 @@ const enableServiceWorker =
 
 const ProviderWrapper = ({ children }) => (
     <Provider store={store}>
-        <OnboardProviderWrapper>
-            <GoodXProvider nativeBaseProps={{ config: { suppressColorAccessibilityWarning: true }, theme: nbTheme }}>
-                <Web3ContextProvider>
-                    <LanguageProvider>
-                        <PostHogProvider
-                            apiKey={import.meta.env.REACT_APP_POSTHOG_KEY}
-                            options={{
-                                host: import.meta.env.REACT_APP_POSTHOG_PROXY ?? 'https://app.posthog.com',
-                            }}
-                            autocapture={false}
-                        >
-                            {children}
-                        </PostHogProvider>
-                    </LanguageProvider>
-                </Web3ContextProvider>
-            </GoodXProvider>
-        </OnboardProviderWrapper>
+        <PostHogProvider
+            apiKey={import.meta.env.REACT_APP_POSTHOG_KEY}
+            options={{
+                host: import.meta.env.REACT_APP_POSTHOG_PROXY ?? 'https://app.posthog.com',
+            }}
+            autocapture={false}
+        >
+            <OnboardProviderWrapper>
+                <GoodXProvider
+                    nativeBaseProps={{ config: { suppressColorAccessibilityWarning: true }, theme: nbTheme }}
+                >
+                    <Web3ContextProvider>
+                        <LanguageProvider>{children}</LanguageProvider>
+                    </Web3ContextProvider>
+                </GoodXProvider>
+            </OnboardProviderWrapper>
+        </PostHogProvider>
     </Provider>
 )
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -23,23 +23,8 @@ const RoutesWrapper = () => {
     const [posthogInitialized, setPosthogInitialized] = useState(false)
 
     useEffect(() => {
-        let debounceTimer: any
-
-        const retryFeatureFlags = () => {
-            clearTimeout(debounceTimer)
-            debounceTimer = setTimeout(() => {
-                if (posthog?.getFeatureFlag('goodid')) {
-                    setPosthogInitialized(true)
-                } else {
-                    retryFeatureFlags()
-                }
-            }, 300)
-        }
-
-        retryFeatureFlags()
-
-        return () => {
-            clearTimeout(debounceTimer)
+        if (posthog) {
+            posthog.onFeatureFlags(() => setPosthogInitialized(true))
         }
     }, [posthog])
 


### PR DESCRIPTION
# Description
https://posthog.com/docs/feature-flags/adding-feature-flag-code#ensuring-flags-are-loaded-before-usage
**'Except for the first time a user visits'**

A new user visiting can get stuck on pages relying on feature-flags. the feature flags only load properly after a refresh, or navigating pages.

This PR adds a wrapper to wait for them to be loaded before loading any routes.
