### PR TITLE
Fix uniswap crashes

### DIFF
--- a/docs/patch_reference.md
+++ b/docs/patch_reference.md
@@ -19,3 +19,11 @@
     -   Fix double hover selector in tokenlist.
     -   Fix for modal on Safari.
 -   Don't enforce permit2 when using minipay
+
+## @uniswap/widgets@npm:2.59.0
+
+-   Fix price impact calculation crashes:
+    -   Add defensive checks for NaN, Infinity, and division by zero in `usePriceImpact` function
+    -   Add defensive checks for invalid price impact values in `getPriceImpactWarning` function
+    -   Prevents "something went wrong" errors on high price impact trades (100%+)
+    -   Shows clear warnings instead of crashes

--- a/src/pages/gd/Swap/SwapCelo/UniSwap.tsx
+++ b/src/pages/gd/Swap/SwapCelo/UniSwap.tsx
@@ -23,67 +23,13 @@ import { useDispatch } from 'react-redux'
 import { addTransaction } from 'state/transactions/actions'
 import { ChainId } from '@sushiswap/sdk'
 import { isMobile } from 'react-device-detect'
-import { Center, Text, Button } from 'native-base'
+import { Center } from 'native-base'
 
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useApplicationTheme } from 'state/application/hooks'
 import useSendAnalytics from 'hooks/useSendAnalyticsData'
 import { tokens } from './celo-tokenlist.json'
-
-// Error Boundary Component for Uniswap Widget
-interface ErrorBoundaryState {
-    hasError: boolean
-    error: Error | null
-}
-
-class SwapWidgetErrorBoundary extends React.Component<{ children: React.ReactNode }, ErrorBoundaryState> {
-    constructor(props: { children: React.ReactNode }) {
-        super(props)
-        this.state = { hasError: false, error: null }
-    }
-
-    static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-        return { hasError: true, error }
-    }
-
-    componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-        console.error('SwapWidget Error Boundary caught an error:', error, errorInfo)
-    }
-
-    render() {
-        if (this.state.hasError) {
-            return (
-                <div
-                    style={{
-                        padding: '20px',
-                        textAlign: 'center',
-                        border: '1px solid #ff6b6b',
-                        borderRadius: '8px',
-                        backgroundColor: '#fff5f5',
-                        margin: '10px 0',
-                    }}
-                >
-                    <Text fontSize="lg" color="red.500" mb={3}>
-                        Swap Widget Error
-                    </Text>
-                    <Text fontSize="md" color="gray.600" mb={4}>
-                        The swap widget encountered an error. This might be due to extreme price impact or insufficient
-                        liquidity.
-                    </Text>
-                    <Button
-                        colorScheme="blue"
-                        size="sm"
-                        onPress={() => this.setState({ hasError: false, error: null })}
-                    >
-                        Try Again
-                    </Button>
-                </div>
-            )
-        }
-
-        return this.props.children
-    }
-}
+import { classifySwapError } from 'utils/swapErrors'
 
 const jsonRpcUrlMap = {
     122: ['https://rpc.fuse.io', 'https://fuse-pokt.nodies.app', 'https://fuse.liquify.com'],
@@ -154,35 +100,11 @@ export const UniSwap = (): JSX.Element => {
     const handleError = useCallback(
         async (e) => {
             console.error('Uniswap widget error:', e)
-
-            // Check for division by zero or extreme price impact errors
-            const errorMessage = e.message || e.toString()
-            const isDivisionByZero =
-                errorMessage.includes('division by zero') ||
-                errorMessage.includes('Infinity') ||
-                errorMessage.includes('NaN')
-
-            const isPriceImpactError = errorMessage.includes('price impact') || errorMessage.includes('impact')
-
-            if (isDivisionByZero || isPriceImpactError) {
-                // Show user-friendly message for extreme price impact scenarios
-                const userFriendlyError = {
-                    message:
-                        'This trade has an extremely high price impact (100% or more). This usually means insufficient liquidity for this trade amount. Please try a smaller amount or check if the tokens have enough liquidity.',
-                    type: 'price_impact_error',
-                }
-
-                sendData({
-                    event: 'swap',
-                    action: 'swap_failed',
-                    error: userFriendlyError.message,
-                })
-
-                // You could also show a toast notification here if you have a toast system
-                console.warn('Extreme price impact detected:', userFriendlyError.message)
-            } else {
-                // Handle other errors normally
-                sendData({ event: 'swap', action: 'swap_failed', error: errorMessage })
+            const raw = e.message || String(e)
+            const { type, message } = classifySwapError(raw)
+            sendData({ event: 'swap', action: 'swap_failed', error: message })
+            if (type === 'price_impact_error') {
+                console.warn('Extreme price impact detected:', message)
             }
         },
         [sendData]
@@ -277,31 +199,29 @@ export const UniSwap = (): JSX.Element => {
 
     return (
         <Center w={'auto'} maxW="550" alignSelf="center">
-            <SwapWidgetErrorBoundary>
-                <SwapWidget
-                    width={'auto'}
-                    tokenList={tokens}
-                    defaultInputTokenAddress={cusdTokenAddress}
-                    defaultOutputTokenAddress={gdTokenAddress}
-                    settings={{
-                        slippage: { auto: false, max: '0.3' },
-                        routerPreference: RouterPreference.API,
-                        transactionTtl: 30,
-                    }}
-                    permit2={!isMinipay} // disable for minipay?
-                    jsonRpcUrlMap={jsonRpcUrlMap}
-                    routerUrl={'https://api.uniswap.org/v1/'}
-                    provider={web3Provider}
-                    theme={customTheme}
-                    hideConnectionUI
-                    onConnectWalletClick={connectOnboard}
-                    onError={handleError}
-                    onTxFail={handleTxFailed}
-                    onTxSubmit={handleTxSubmit}
-                    onTxSuccess={handleTxSuccess}
-                    dialogOptions={{ pageCentered: !!isMobile }}
-                />
-            </SwapWidgetErrorBoundary>
+            <SwapWidget
+                width={'auto'}
+                tokenList={tokens}
+                defaultInputTokenAddress={cusdTokenAddress}
+                defaultOutputTokenAddress={gdTokenAddress}
+                settings={{
+                    slippage: { auto: false, max: '0.3' },
+                    routerPreference: RouterPreference.API,
+                    transactionTtl: 30,
+                }}
+                permit2={!isMinipay} // disable for minipay?
+                jsonRpcUrlMap={jsonRpcUrlMap}
+                routerUrl={'https://api.uniswap.org/v1/'}
+                provider={web3Provider}
+                theme={customTheme}
+                hideConnectionUI
+                onConnectWalletClick={connectOnboard}
+                onError={handleError}
+                onTxFail={handleTxFailed}
+                onTxSubmit={handleTxSubmit}
+                onTxSuccess={handleTxSuccess}
+                dialogOptions={{ pageCentered: !!isMobile }}
+            />
         </Center>
     )
 }

--- a/src/utils/swapErrors.ts
+++ b/src/utils/swapErrors.ts
@@ -1,0 +1,17 @@
+export function isDivisionByZero(msg: string): boolean {
+    return /division by zero|Infinity|NaN/i.test(msg)
+}
+
+export function isPriceImpactError(msg: string): boolean {
+    return /price impact|impact/i.test(msg)
+}
+
+export function classifySwapError(raw: string) {
+    if (isDivisionByZero(raw) || isPriceImpactError(raw)) {
+        return {
+            type: 'price_impact_error' as const,
+            message: 'High price impact detected. Try a smaller amount or check token liquidity.',
+        }
+    }
+    return { type: 'generic_error' as const, message: raw }
+}

--- a/src/utils/swapErrors.ts
+++ b/src/utils/swapErrors.ts
@@ -1,9 +1,9 @@
 export function isDivisionByZero(msg: string): boolean {
-    return /division by zero|Infinity|NaN/i.test(msg)
+    return /(division\s+by\s+zero|divided\s+by\s+zero|\bInfinity\b|\bNaN\b)/i.test(msg)
 }
 
 export function isPriceImpactError(msg: string): boolean {
-    return /price impact|impact/i.test(msg)
+    return /price\s+impact/i.test(msg)
 }
 
 export function classifySwapError(raw: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12204,7 +12204,7 @@ __metadata:
 
 "@uniswap/widgets@patch:@uniswap/widgets@npm%3A2.59.0#./.yarn/patches/@uniswap-widgets-npm-2.59.0-6bf5828475.patch::locator=%40gooddollar%2Fprotocol-ui%40workspace%3A.":
   version: 2.59.0
-  resolution: "@uniswap/widgets@patch:@uniswap/widgets@npm%3A2.59.0#./.yarn/patches/@uniswap-widgets-npm-2.59.0-6bf5828475.patch::version=2.59.0&hash=2fee72&locator=%40gooddollar%2Fprotocol-ui%40workspace%3A."
+  resolution: "@uniswap/widgets@patch:@uniswap/widgets@npm%3A2.59.0#./.yarn/patches/@uniswap-widgets-npm-2.59.0-6bf5828475.patch::version=2.59.0&hash=37910f&locator=%40gooddollar%2Fprotocol-ui%40workspace%3A."
   dependencies:
     "@babel/runtime": ">=7.17.0"
     "@fontsource/ibm-plex-mono": ^4.5.1
@@ -12277,7 +12277,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 6ede2cfbf6633dda76d66925de64ac603f40af5b1d71697d9f46546def67717571f0126fb550c806803b04096e46d18e30310ed036a7def98dae4fed0d652c4f
+  checksum: 6460a84a8f6147c00d3e240aabb6632773c6ebf621db0136474c7e9be21b42da6e1bacf13c757b2a1a2ff3f70573ccf6451c29673cc95577b680e73de90c2a5c
   languageName: node
   linkType: hard
 
@@ -16432,9 +16432,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001464, caniuse-lite@npm:^1.0.30001587":
-  version: 1.0.30001600
-  resolution: "caniuse-lite@npm:1.0.30001600"
-  checksum: 1aae03be0e9f96163e88b9305531ef8db0e01f224aff545c61a32ce0b0ca323e22531bf680bacac3e34f98e23f71ac31a21b328fa0fcbbecea65a2c2638c70c4
+  version: 1.0.30001727
+  resolution: "caniuse-lite@npm:1.0.30001727"
+  checksum: 2bc6112f242701198a99c17713d4409be9b404d09005f34f351ec29a4ea46c054e7aa4982bc16f06b81b7a375cbc61c937e89650170cbce84db772a376ed3963
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
##  UI Demo - Uniswap Widget Crash Prevention Fix

### Problem Solved
Previously, entering extremely large amounts (like 10+ trillion tokens) would cause the Uniswap widget to crash with "something went wrong" errors due to price impact calculation failures.

### Fix Demonstration

**Scenario 1: 10 trillion G$ → cUSD**
<img width="1671" height="896" alt="Screenshot 2025-07-21 at 14 51 03" src="https://github.com/user-attachments/assets/62465487-085a-40ad-9b7e-119f5dcf48b1" />

- Widget remains functional instead of crashing
- Gracefully handles impossible calculation (shows 0 output)
- No "something went wrong" error

**Scenario 2: 10 billion G$ → cUSD** 
<img width="1671" height="896" alt="Screenshot 2025-07-21 at 14 53 12" src="https://github.com/user-attachments/assets/f80eef6c-ee16-469d-b021-cfd9dd9a826c" />

- Shows proper price impact warning (98.987%)
- Widget calculates and displays warning correctly
- User can see the extreme impact before proceeding

### Technical Implementation
- Added defensive error handling in `onError` callback
- Implemented `classifySwapError` utility for better error classification  
- Prevents crashes on extreme price impact calculations (100%+)
- Maintains widget functionality during edge cases

### Result
The widget now handles extreme scenarios gracefully with clear warnings instead of crashing, providing a much better user experience.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Implement defensive error handling and improve error classification to prevent crashes in Uniswap when high price impacts occur or calculations yield invalid results.

### Why are these changes being made?
Uniswap was experiencing crashes due to price impact calculations yielding NaN, Infinity, or division by zero, primarily on high-impact trades. This approach prevents errors by adding checks for these conditions and classifying the errors with appropriate messages, offering users clear warnings rather than experiencing a crash.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->