### PR TITLE
add: verify rpcs and fallback for reown/viem

### DIFF
--- a/src/hooks/useWeb3.tsx
+++ b/src/hooks/useWeb3.tsx
@@ -67,19 +67,14 @@ async function testRpc(rpcUrl: string): Promise<boolean> {
         if (!response.ok) return false
 
         const data = await response.json()
-        return !data.error && (data.result !== undefined || data.result !== null)
+        return !data.error && !!data.result
     } catch {
         return false
     }
 }
 
 async function fetchAndTestRpcs(): Promise<Record<string, string[]>> {
-    const rpcsByChain: Record<string, string[]> = {
-        MAINNET_RPC: [],
-        FUSE_RPC: [],
-        CELO_RPC: [],
-        XDC_RPC: [],
-    }
+    const rpcsByChain: Record<string, string[]> = {}
 
     try {
         console.log('[fetchAndTestRpcs] Starting RPC fetch and test...')

--- a/src/reown/reownprovider.tsx
+++ b/src/reown/reownprovider.tsx
@@ -160,7 +160,10 @@ export function AppKitProvider({ children }: { children: React.ReactNode }) {
             if (rpcUrls) {
                 set(network, 'rpcUrls.default.http', rpcUrls)
                 console.log(`Reown: Updated RPC for ${network.name} to ${rpcUrls}`)
-                transports[network.id] = fallback(rpcUrls.map((_) => http(_)))
+                transports[network.id] = fallback(
+                    rpcUrls.map((_) => http(_)),
+                    { rank: true, retryCount: 3, retryDelay: 1000 }
+                )
                 // network.rpcUrls = updatedNetwork.rpcUrls
             }
         })


### PR DESCRIPTION
# Description

- Added a method to fetch current RPCs from chainlist.org code base
- Test max 10 rpcs for each network for liveness
- For backward compatability sample 1 rpc from working rpcs
- For reown use working rpc list in wagmi configuration, and define fallback transport
- Loading urls first time will take a little longer, subsequent fetches once per day will first use previous cache and retest urls in background