### PR TITLE
fix: disable claim button while loading claim data after network switch

### DIFF
--- a/src/pages/gd/Claim/OldClaim.tsx
+++ b/src/pages/gd/Claim/OldClaim.tsx
@@ -11,7 +11,7 @@ import {
     useScreenSize,
     ClaimSuccessModal,
 } from '@gooddollar/good-design'
-import { Box, Center, Text, useBreakpointValue } from 'native-base'
+import { Box, Center, Spinner, Text, useBreakpointValue } from 'native-base'
 import { useConnectionInfo } from 'hooks/useConnectionInfo'
 import {
     useClaim,
@@ -407,16 +407,22 @@ const OldClaim = memo(() => {
                                         </>
                                     )}
 
-                                    <ClaimButton
-                                        firstName="Test"
-                                        method="redirect"
-                                        claim={handleClaim}
-                                        claimed={claimed}
-                                        claiming={state}
-                                        handleConnect={handleConnect}
-                                        chainId={+(chainId ?? 42220)}
-                                        onEvent={handleEvents}
-                                    />
+                                    {claimed === undefined ? (
+                                        <Center pt="8" pb="8">
+                                            <Spinner size="lg" color="gdPrimary" />
+                                        </Center>
+                                    ) : (
+                                        <ClaimButton
+                                            firstName="Test"
+                                            method="redirect"
+                                            claim={handleClaim}
+                                            claimed={claimed}
+                                            claiming={state}
+                                            handleConnect={handleConnect}
+                                            chainId={+(chainId ?? 42220)}
+                                            onEvent={handleEvents}
+                                        />
+                                    )}
                                     {isHoliday ? (
                                         <Center maxW="390" width="100%" mb={8}>
                                             <Image


### PR DESCRIPTION
## Problem

When switching networks, the claim button appears clickable (blue, showing "CLAIM NOW") even though claim data hasn't loaded yet. Pressing it does nothing because the underlying blockchain calls haven't completed.

**Root cause:** In `OldClaim.tsx`, when the chain ID changes, `claimed` is set to `undefined` while claim data loads:

```typescript
useEffect(() => {
    setClaimed(undefined)
    setRefreshRate('everyBlock')
}, [chainId])
```

The `ClaimButton` component from `@gooddollar/good-design` uses `disabled={claimed}`. When `claimed === undefined`, this evaluates to `disabled={undefined}` (falsy), leaving the button enabled during loading.

## Solution

Show a loading spinner while `claimed === undefined` (data loading state), and render the `ClaimButton` only when claim data has loaded (`claimed` is `true` or `false`).

## Changes

- Added `Spinner` import from `native-base`
- Wrapped `ClaimButton` with conditional rendering: show spinner when loading, button when ready

## Testing

1. Connect wallet on one network (e.g., Celo)
2. Switch to another network (e.g., XDC)  
3. Observe: spinner appears instead of clickable button
4. Once claim data loads, button appears with correct amount

Fixes #614

## Summary by Sourcery

Bug Fixes:
- Prevent the claim button from appearing clickable while claim data is still loading by showing a spinner until the claimed state is resolved.